### PR TITLE
Create Genre ViewSet and Related Tests

### DIFF
--- a/rmmapi/views/__init__.py
+++ b/rmmapi/views/__init__.py
@@ -1,3 +1,4 @@
 """Views Package"""
 from .auth import login_user, register_user
 from .artist import ArtistViewSet
+from .genre import GenreViewSet

--- a/rmmapi/views/artist.py
+++ b/rmmapi/views/artist.py
@@ -4,7 +4,6 @@ from django.core.exceptions import ValidationError
 from rest_framework import status, serializers
 from rest_framework.viewsets import ViewSet
 from rest_framework.response import Response
-from rest_framework.decorators import permission_classes
 from rmmapi.models import Artist, Rater
 from rmmapi.permissions import MustBeCreatorToModify
 

--- a/rmmapi/views/genre.py
+++ b/rmmapi/views/genre.py
@@ -1,0 +1,27 @@
+"""Genre ViewSet and Serializers"""
+from rest_framework import serializers
+from rest_framework.viewsets import ViewSet
+from rest_framework.response import Response
+from rmmapi.models import Genre
+
+class GenreSerializer(serializers.ModelSerializer):
+    """JSON serializer for genre"""
+
+    class Meta:
+        model = Genre
+        fields = ('id', 'name')
+
+class GenreViewSet(ViewSet):
+    def list(self, request):
+        genres = Genre.objects.all()
+
+        q = request.query_params.get('q', None)
+        if q is not None:
+            genres = self._filter_by_search_term(genres, q)
+
+        serializer = GenreSerializer(genres, many=True)
+        return Response(serializer.data)
+
+    def _filter_by_search_term(self, genres, q):
+        """Given a Genres QuerySet, filter by those whose name contains search term q, case-insensitive"""
+        return genres.filter(name__icontains=q)

--- a/server/urls.py
+++ b/server/urls.py
@@ -3,10 +3,11 @@ from django.urls import path
 from django.conf.urls import include
 from rest_framework import routers
 from rmmapi.views import login_user, register_user
-from rmmapi.views import ArtistViewSet
+from rmmapi.views import ArtistViewSet, GenreViewSet
 
 router = routers.DefaultRouter(trailing_slash=False)
 router.register(r'artists', ArtistViewSet, 'artist')
+router.register(r'genres', GenreViewSet, 'genre')
 
 urlpatterns = [
     path('', include(router.urls)),

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,2 +1,3 @@
 from .auth import AuthTests 
 from .artist import ArtistTests
+from .genre import GenreTests

--- a/tests/genre.py
+++ b/tests/genre.py
@@ -1,0 +1,52 @@
+import json
+from rest_framework import status
+from rest_framework.test import APITestCase
+from rmmapi.models import Genre
+
+class GenreTests(APITestCase):
+    def setUp(self):
+        """Create an account and set up auth header for future HTTP requests. Create two genres."""
+        data = {
+            'username': 'jweckert17',
+            'email': 'jweckert17@gmail.com',
+            'password': 'test',
+            'first_name': 'Jacob',
+            'last_name': 'Eckert',
+            'bio': 'I am just a cool boi.'
+        }
+
+        response = self.client.post('/register', data, format='json')
+        json_response = json.loads(response.content)
+        self.token = json_response['token']
+        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.token)
+
+        genre_1 = Genre(name="Indie Pop")
+        genre_1.save()
+
+        genre_2 = Genre(name="Indie Folk")
+        genre_2.save()
+
+    def test_get_all_genres(self):
+        """Test getting all genres"""
+        response = self.client.get('/genres')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        genres = json.loads(response.content)
+        self.assertEqual(len(genres), 2)
+
+        self.assertEqual(genres[0]['id'], 1)
+        self.assertEqual(genres[0]['name'], 'Indie Pop')
+
+        self.assertEqual(genres[1]['id'], 2)
+        self.assertEqual(genres[1]['name'], 'Indie Folk')
+
+    def test_get_all_genres_by_search_term_with_one_match(self):
+        """Test getting genres by search term only one matches"""
+        response = self.client.get('/genres?q=folk')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        genres = json.loads(response.content)
+        self.assertEqual(len(genres), 1)
+
+        self.assertEqual(genres[0]['id'], 2)
+        self.assertEqual(genres[0]['name'], 'Indie Folk')


### PR DESCRIPTION
This PR implements a genre viewset, hooks it up to /genres, and implements the list method to get all genres with optional query string parameter `q`. It implements tests for this.