### PR TITLE
set MustBeCreatorToModify permission as default project permission class

### DIFF
--- a/rmmapi/views/artist.py
+++ b/rmmapi/views/artist.py
@@ -5,7 +5,6 @@ from rest_framework import status, serializers
 from rest_framework.viewsets import ViewSet
 from rest_framework.response import Response
 from rmmapi.models import Artist, Rater
-from rmmapi.permissions import MustBeCreatorToModify
 
 class ArtistSerializer(serializers.ModelSerializer):
     """JSON serializer for artist"""
@@ -14,8 +13,6 @@ class ArtistSerializer(serializers.ModelSerializer):
         fields = ('id', 'name', 'founded_year', 'description')
 
 class ArtistViewSet(ViewSet):
-    permission_classes = (MustBeCreatorToModify, )
-
     def create(self, request):
         """POST a new artist"""
         missing_keys = self._get_missing_keys()

--- a/server/settings.py
+++ b/server/settings.py
@@ -48,7 +48,7 @@ REST_FRAMEWORK = {
         'rest_framework.authentication.TokenAuthentication',
     ),
     'DEFAULT_PERMISSION_CLASSES': [
-        'rest_framework.permissions.IsAuthenticated',
+        'rmmapi.permissions.MustBeCreatorToModify',
     ],
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.LimitOffsetPagination',
     'PAGE_SIZE': 10


### PR DESCRIPTION
This PR moves the custom permission class MustBeCreatorToModify from being explicitly specified in the Artist ViewSet (and subsequentially would have been necessary to explicitly set in all viewsets), to being the default permission class for the whole app. 