### PR TITLE
Pagination

### DIFF
--- a/rmmapi/helpers/__init__.py
+++ b/rmmapi/helpers/__init__.py
@@ -1,1 +1,2 @@
 from .get_missing_keys import get_missing_keys
+from .paginate import paginate

--- a/rmmapi/helpers/paginate.py
+++ b/rmmapi/helpers/paginate.py
@@ -1,0 +1,15 @@
+def paginate(collection, page, page_size):
+    try:
+        page = int(page)
+    except ValueError:
+        page = 1
+
+    try:
+        page_size = int(page_size)
+    except ValueError:
+        page_size = 10
+
+    page = page - 1
+    start_index = (page * page_size)
+    end_index = ((page + 1) * page_size)
+    return collection[start_index:end_index]

--- a/rmmapi/views/artist.py
+++ b/rmmapi/views/artist.py
@@ -85,8 +85,13 @@ class ArtistViewSet(ViewSet):
         if q is not None:
             artists = self._filter_by_search_term(artists, q)
 
+        count = len(artists)
+
         serializer = ArtistSerializer(artists, many=True)
-        return Response(serializer.data)
+        return Response({
+            "data": serializer.data,
+            "count": count
+        })
 
     def _validate(self):
         """Validate values sent in POST/PUT body - 

--- a/rmmapi/views/genre.py
+++ b/rmmapi/views/genre.py
@@ -19,8 +19,13 @@ class GenreViewSet(ViewSet):
         if q is not None:
             genres = self._filter_by_search_term(genres, q)
 
+        count = len(genres)
+
         serializer = GenreSerializer(genres, many=True)
-        return Response(serializer.data)
+        return Response({
+            "data": serializer.data,
+            "count": count
+        })
 
     def _filter_by_search_term(self, genres, q):
         """Given a Genres QuerySet, filter by those whose name contains search term q, case-insensitive"""

--- a/rmmapi/views/list.py
+++ b/rmmapi/views/list.py
@@ -6,7 +6,7 @@ from rest_framework import serializers, status
 from rest_framework.viewsets import ViewSet
 from rest_framework.response import Response
 from rest_framework.decorators import action
-from rmmapi.helpers import get_missing_keys
+from rmmapi.helpers import get_missing_keys, paginate
 from rmmapi.models import List, Song, ListSong, Rater, ListFavorite
 from .rater import RaterSerializer
 
@@ -153,6 +153,8 @@ class ListViewSet(ViewSet):
         song_id = request.query_params.get('songId', None)
         user_id = request.query_params.get('userId', None)
         favoritedBy = request.query_params.get('favoritedBy', None)
+        page = request.query_params.get('page', None)
+        pageSize = request.query_params.get('pageSize', 10)
 
         if song_id is not None:
             lists = lists.filter(songs__song_id=song_id).distinct()
@@ -162,6 +164,9 @@ class ListViewSet(ViewSet):
 
         if favoritedBy is not None:
             lists = lists.filter(favorites__rater_id=favoritedBy)
+
+        if page is not None:
+            lists = paginate(lists, page, pageSize)
 
         serializer = SimpleListSerializer(lists, many=True)
         return Response(serializer.data)

--- a/rmmapi/views/list.py
+++ b/rmmapi/views/list.py
@@ -165,11 +165,16 @@ class ListViewSet(ViewSet):
         if favoritedBy is not None:
             lists = lists.filter(favorites__rater_id=favoritedBy)
 
+        count = len(lists)
+
         if page is not None:
             lists = paginate(lists, page, pageSize)
 
         serializer = SimpleListSerializer(lists, many=True)
-        return Response(serializer.data)
+        return Response({
+            "data": serializer.data,
+            "count": count
+        })
 
     @action(methods=['post', 'delete'], detail=True)
     def favorite(self, request, pk=None):

--- a/rmmapi/views/rating.py
+++ b/rmmapi/views/rating.py
@@ -105,11 +105,16 @@ class RatingViewSet(ViewSet):
 
         ratings = self._sort_by_query_string_param(ratings)
 
+        count = len(ratings)
+
         if page is not None:
             ratings = paginate(ratings, page, pageSize)
 
         serializer = RatingSerializer(ratings, many=True)
-        return Response(serializer.data)
+        return Response({
+            "data": serializer.data,
+            "count": count
+        })
 
     def _validate(self):
         """Validate values sent in POST/PUT body - 

--- a/rmmapi/views/rating.py
+++ b/rmmapi/views/rating.py
@@ -6,7 +6,7 @@ from rest_framework import status, serializers
 from rest_framework.viewsets import ViewSet
 from rest_framework.response import Response
 from rmmapi.models import Rating, Song, Rater
-from rmmapi.helpers import get_missing_keys
+from rmmapi.helpers import get_missing_keys, paginate
 from .rater import RaterSerializer
 from .song import SongSerializer
 
@@ -94,6 +94,8 @@ class RatingViewSet(ViewSet):
 
         user_id = request.query_params.get('userId', None)
         song_id = request.query_params.get('songId', None)
+        page = request.query_params.get('page', None)
+        pageSize = request.query_params.get('pageSize', 10)
 
         if user_id is not None:
             ratings = ratings.filter(rater_id=user_id)
@@ -102,6 +104,9 @@ class RatingViewSet(ViewSet):
             ratings = ratings.filter(song_id=song_id)
 
         ratings = self._sort_by_query_string_param(ratings)
+
+        if page is not None:
+            ratings = paginate(ratings, page, pageSize)
 
         serializer = RatingSerializer(ratings, many=True)
         return Response(serializer.data)

--- a/rmmapi/views/song.py
+++ b/rmmapi/views/song.py
@@ -216,11 +216,16 @@ class SongViewSet(ViewSet):
 
         songs = self._sort_by_query_string_param(songs)
 
+        count = len(songs)
+
         if page is not None:
             songs = paginate(songs, page, pageSize)
 
         serializer = SongSerializer(songs, many=True)
-        return Response(serializer.data)
+        return Response({
+            "data": serializer.data,
+            "count": count
+        })
         
     def _validate(self):
         """Validate values sent in POST/PUT body - 

--- a/rmmapi/views/song.py
+++ b/rmmapi/views/song.py
@@ -186,7 +186,7 @@ class SongViewSet(ViewSet):
         genres = request.query_params.get('genres', None)
         artist = request.query_params.get('artist', None)
         q = request.query_params.get('q', None)
-        page = request.query_params.get('page', 1)
+        page = request.query_params.get('page', None)
         pageSize = request.query_params.get('pageSize', 10)
 
         if startYear is not None:
@@ -216,7 +216,8 @@ class SongViewSet(ViewSet):
 
         songs = self._sort_by_query_string_param(songs)
 
-        songs = paginate(songs, page, pageSize)
+        if page is not None:
+            songs = paginate(songs, page, pageSize)
 
         serializer = SongSerializer(songs, many=True)
         return Response(serializer.data)

--- a/rmmapi/views/song.py
+++ b/rmmapi/views/song.py
@@ -1,5 +1,6 @@
 """Song ViewSet and Serializers"""
 from django.db.models import Q
+from django.db.models.expressions import Value
 from django.db.models.functions import Lower
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
@@ -7,7 +8,7 @@ from django.core.exceptions import ValidationError
 from rest_framework import status, serializers
 from rest_framework.viewsets import ViewSet
 from rest_framework.response import Response
-from rmmapi.helpers import get_missing_keys
+from rmmapi.helpers import get_missing_keys, paginate
 from rmmapi.models import Artist, Genre, Rater, Song, SongGenre, SongSource
 
 class SongGenresSerializer(serializers.ModelSerializer):
@@ -185,6 +186,8 @@ class SongViewSet(ViewSet):
         genres = request.query_params.get('genres', None)
         artist = request.query_params.get('artist', None)
         q = request.query_params.get('q', None)
+        page = request.query_params.get('page', 1)
+        pageSize = request.query_params.get('pageSize', 10)
 
         if startYear is not None:
             try:
@@ -212,6 +215,8 @@ class SongViewSet(ViewSet):
             songs = songs.filter(Q(artist__name__icontains=q) | Q(name__icontains=q))
 
         songs = self._sort_by_query_string_param(songs)
+
+        songs = paginate(songs, page, pageSize)
 
         serializer = SongSerializer(songs, many=True)
         return Response(serializer.data)

--- a/tests/artist.py
+++ b/tests/artist.py
@@ -207,11 +207,11 @@ class ArtistTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         artists = json.loads(response.content)
-        self.assertEqual(len(artists), 1)
-        self.assertEqual(artists[0]['id'], 1)
-        self.assertEqual(artists[0]['name'], 'The Magnetic Fields')
-        self.assertEqual(artists[0]['founded_year'], 1990)
-        self.assertEqual(artists[0]['description'], 'An amazing band.')
+        self.assertEqual(artists['count'], 1)
+        self.assertEqual(artists['data'][0]['id'], 1)
+        self.assertEqual(artists['data'][0]['name'], 'The Magnetic Fields')
+        self.assertEqual(artists['data'][0]['founded_year'], 1990)
+        self.assertEqual(artists['data'][0]['description'], 'An amazing band.')
 
     def test_get_all_artists_by_matching_search_term(self):
         """Test getting all artists using the q query string parameter and a matching name"""
@@ -221,11 +221,11 @@ class ArtistTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         artists = json.loads(response.content)
-        self.assertEqual(len(artists), 1)
-        self.assertEqual(artists[0]['id'], 1)
-        self.assertEqual(artists[0]['name'], 'The Magnetic Fields')
-        self.assertEqual(artists[0]['founded_year'], 1990)
-        self.assertEqual(artists[0]['description'], 'An amazing band.')
+        self.assertEqual(artists['count'], 1)
+        self.assertEqual(artists['data'][0]['id'], 1)
+        self.assertEqual(artists['data'][0]['name'], 'The Magnetic Fields')
+        self.assertEqual(artists['data'][0]['founded_year'], 1990)
+        self.assertEqual(artists['data'][0]['description'], 'An amazing band.')
 
     def test_get_all_artists_by_non_matching_search_term(self):
         """Test getting all artists using the q query string parameter and a non-matching name"""
@@ -235,4 +235,4 @@ class ArtistTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         artists = json.loads(response.content)
-        self.assertEqual(len(artists), 0)
+        self.assertEqual(artists['count'], 0)

--- a/tests/genre.py
+++ b/tests/genre.py
@@ -32,13 +32,13 @@ class GenreTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         genres = json.loads(response.content)
-        self.assertEqual(len(genres), 2)
+        self.assertEqual(genres['count'], 2)
 
-        self.assertEqual(genres[0]['id'], 1)
-        self.assertEqual(genres[0]['name'], 'Indie Pop')
+        self.assertEqual(genres['data'][0]['id'], 1)
+        self.assertEqual(genres['data'][0]['name'], 'Indie Pop')
 
-        self.assertEqual(genres[1]['id'], 2)
-        self.assertEqual(genres[1]['name'], 'Indie Folk')
+        self.assertEqual(genres['data'][1]['id'], 2)
+        self.assertEqual(genres['data'][1]['name'], 'Indie Folk')
 
     def test_get_all_genres_by_search_term_with_one_match(self):
         """Test getting genres by search term only one matches"""
@@ -46,7 +46,7 @@ class GenreTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         genres = json.loads(response.content)
-        self.assertEqual(len(genres), 1)
+        self.assertEqual(genres['count'], 1)
 
-        self.assertEqual(genres[0]['id'], 2)
-        self.assertEqual(genres[0]['name'], 'Indie Folk')
+        self.assertEqual(genres['data'][0]['id'], 2)
+        self.assertEqual(genres['data'][0]['name'], 'Indie Folk')

--- a/tests/list.py
+++ b/tests/list.py
@@ -280,9 +280,9 @@ class ListTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         lists = json.loads(response.content)
-        self.assertEqual(len(lists), 2)
-        self.assertEqual(lists[0]['name'], 'My List')
-        self.assertEqual(lists[1]['name'], 'My Second List')
+        self.assertEqual(lists['count'], 2)
+        self.assertEqual(lists['data'][0]['name'], 'My List')
+        self.assertEqual(lists['data'][1]['name'], 'My Second List')
 
     def test_get_all_lists_by_song_id(self):
         self.test_create_valid_list()
@@ -292,8 +292,8 @@ class ListTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         lists = json.loads(response.content)
-        self.assertEqual(len(lists), 1)
-        self.assertEqual(lists[0]['name'], 'My List')
+        self.assertEqual(lists['count'], 1)
+        self.assertEqual(lists['data'][0]['name'], 'My List')
 
     def test_get_all_lists_by_user_id(self):
         self.test_create_valid_list()
@@ -303,8 +303,8 @@ class ListTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         lists = json.loads(response.content)
-        self.assertEqual(len(lists), 1)
-        self.assertEqual(lists[0]['name'], 'My Second List')
+        self.assertEqual(lists['count'], 1)
+        self.assertEqual(lists['data'][0]['name'], 'My Second List')
 
     def test_get_all_lists_by_favorted_for_user_with_favorites(self):
         self.test_create_valid_list()
@@ -316,8 +316,8 @@ class ListTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         lists = json.loads(response.content)
 
-        self.assertEqual(len(lists), 1)
-        self.assertEqual(lists[0]['id'], 1)
+        self.assertEqual(lists['count'], 1)
+        self.assertEqual(lists['data'][0]['id'], 1)
 
     def test_get_all_lists_by_favorted_for_user_with_no_favorites(self):
         self.test_create_valid_list()
@@ -327,7 +327,7 @@ class ListTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         lists = json.loads(response.content)
 
-        self.assertEqual(len(lists), 0)
+        self.assertEqual(lists['count'], 0)
 
     def test_favorite_list_by_invalid_id(self):
         response = self.client.post('/lists/1/favorite')

--- a/tests/rating.py
+++ b/tests/rating.py
@@ -211,17 +211,17 @@ class RatingTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         ratings = json.loads(response.content)
-        self.assertEqual(len(ratings), 2)
-        self.assertEqual(ratings[0]['id'], 1)
-        self.assertEqual(ratings[0]['rating'], 3)
-        self.assertEqual(ratings[0]['review'], 'So good!')
-        self.assertEqual(ratings[0]['rater']['user']['username'], 'jweckert17')
-        self.assertEqual(ratings[0]['song']['name'], 'Save a Secret for the Moon')
-        self.assertEqual(ratings[1]['id'], 2)
-        self.assertEqual(ratings[1]['rating'], 4)
-        self.assertEqual(ratings[1]['review'], 'Very good')
-        self.assertEqual(ratings[1]['rater']['user']['username'], 'test')
-        self.assertEqual(ratings[1]['song']['name'], 'Famous')
+        self.assertEqual(ratings['count'], 2)
+        self.assertEqual(ratings['data'][0]['id'], 1)
+        self.assertEqual(ratings['data'][0]['rating'], 3)
+        self.assertEqual(ratings['data'][0]['review'], 'So good!')
+        self.assertEqual(ratings['data'][0]['rater']['user']['username'], 'jweckert17')
+        self.assertEqual(ratings['data'][0]['song']['name'], 'Save a Secret for the Moon')
+        self.assertEqual(ratings['data'][1]['id'], 2)
+        self.assertEqual(ratings['data'][1]['rating'], 4)
+        self.assertEqual(ratings['data'][1]['review'], 'Very good')
+        self.assertEqual(ratings['data'][1]['rater']['user']['username'], 'test')
+        self.assertEqual(ratings['data'][1]['song']['name'], 'Famous')
 
     def test_get_all_ratings_by_user_id(self):
         self.test_create_valid_rating()
@@ -231,12 +231,12 @@ class RatingTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         ratings = json.loads(response.content)
-        self.assertEqual(len(ratings), 1)
-        self.assertEqual(ratings[0]['id'], 1)
-        self.assertEqual(ratings[0]['rating'], 3)
-        self.assertEqual(ratings[0]['review'], 'So good!')
-        self.assertEqual(ratings[0]['rater']['user']['username'], 'jweckert17')
-        self.assertEqual(ratings[0]['song']['name'], 'Save a Secret for the Moon')
+        self.assertEqual(ratings['count'], 1)
+        self.assertEqual(ratings['data'][0]['id'], 1)
+        self.assertEqual(ratings['data'][0]['rating'], 3)
+        self.assertEqual(ratings['data'][0]['review'], 'So good!')
+        self.assertEqual(ratings['data'][0]['rater']['user']['username'], 'jweckert17')
+        self.assertEqual(ratings['data'][0]['song']['name'], 'Save a Secret for the Moon')
 
     def test_get_all_ratings_by_song_id(self):
         self.test_create_valid_rating()
@@ -246,12 +246,12 @@ class RatingTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         ratings = json.loads(response.content)
-        self.assertEqual(len(ratings), 1)
-        self.assertEqual(ratings[0]['id'], 2)
-        self.assertEqual(ratings[0]['rating'], 4)
-        self.assertEqual(ratings[0]['review'], 'Very good')
-        self.assertEqual(ratings[0]['rater']['user']['username'], 'test')
-        self.assertEqual(ratings[0]['song']['name'], 'Famous')
+        self.assertEqual(ratings['count'], 1)
+        self.assertEqual(ratings['data'][0]['id'], 2)
+        self.assertEqual(ratings['data'][0]['rating'], 4)
+        self.assertEqual(ratings['data'][0]['review'], 'Very good')
+        self.assertEqual(ratings['data'][0]['rater']['user']['username'], 'test')
+        self.assertEqual(ratings['data'][0]['song']['name'], 'Famous')
 
     def test_get_all_ratings_sorted_by_rating_asc(self):
         self.test_create_valid_rating()
@@ -261,9 +261,9 @@ class RatingTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         ratings = json.loads(response.content)
-        self.assertEqual(len(ratings), 2)
-        self.assertEqual(ratings[0]['rating'], 3)
-        self.assertEqual(ratings[1]['rating'], 4)
+        self.assertEqual(ratings['count'], 2)
+        self.assertEqual(ratings['data'][0]['rating'], 3)
+        self.assertEqual(ratings['data'][1]['rating'], 4)
 
     def test_get_all_ratings_sorted_by_rating_desc(self):
         self.test_create_valid_rating()
@@ -273,9 +273,9 @@ class RatingTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         ratings = json.loads(response.content)
-        self.assertEqual(len(ratings), 2)
-        self.assertEqual(ratings[0]['rating'], 4)
-        self.assertEqual(ratings[1]['rating'], 3)
+        self.assertEqual(ratings['count'], 2)
+        self.assertEqual(ratings['data'][0]['rating'], 4)
+        self.assertEqual(ratings['data'][1]['rating'], 3)
 
     def test_get_all_ratings_sorted_by_date_asc(self):
         self.test_create_valid_rating()
@@ -285,9 +285,9 @@ class RatingTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         ratings = json.loads(response.content)
-        self.assertEqual(len(ratings), 2)
-        self.assertEqual(ratings[0]['id'], 1)
-        self.assertEqual(ratings[1]['id'], 2)
+        self.assertEqual(ratings['count'], 2)
+        self.assertEqual(ratings['data'][0]['id'], 1)
+        self.assertEqual(ratings['data'][1]['id'], 2)
 
     def test_get_all_ratings_sorted_by_date_desc(self):
         self.test_create_valid_rating()
@@ -297,9 +297,9 @@ class RatingTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         ratings = json.loads(response.content)
-        self.assertEqual(len(ratings), 2)
-        self.assertEqual(ratings[0]['id'], 2)
-        self.assertEqual(ratings[1]['id'], 1)
+        self.assertEqual(ratings['count'], 2)
+        self.assertEqual(ratings['data'][0]['id'], 2)
+        self.assertEqual(ratings['data'][1]['id'], 1)
 
     def _create_second_song_and_rating_as_second_user(self):
         # create second user and use their credentials

--- a/tests/song.py
+++ b/tests/song.py
@@ -313,9 +313,9 @@ class SongTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         songs = json.loads(response.content)
-        self.assertEqual(len(songs), 2)
-        self.assertEqual(songs[0]['name'], 'Save a Secret for the Moon')
-        self.assertEqual(songs[1]['name'], 'Baby')
+        self.assertEqual(songs['count'], 2)
+        self.assertEqual(songs['data'][0]['name'], 'Save a Secret for the Moon')
+        self.assertEqual(songs['data'][1]['name'], 'Baby')
 
     def test_get_all_songs_with_start_year(self):
         self.test_create_valid_song()
@@ -325,8 +325,8 @@ class SongTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         songs = json.loads(response.content)
-        self.assertEqual(len(songs), 1)
-        self.assertEqual(songs[0]['name'], 'Baby')
+        self.assertEqual(songs['count'], 1)
+        self.assertEqual(songs['data'][0]['name'], 'Baby')
 
     def test_get_all_songs_with_end_year(self):
         self.test_create_valid_song()
@@ -336,8 +336,8 @@ class SongTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         songs = json.loads(response.content)
-        self.assertEqual(len(songs), 1)
-        self.assertEqual(songs[0]['name'], 'Save a Secret for the Moon')
+        self.assertEqual(songs['count'], 1)
+        self.assertEqual(songs['data'][0]['name'], 'Save a Secret for the Moon')
 
     def test_get_all_songs_multiple_genres(self):
         self.test_create_valid_song()
@@ -347,8 +347,8 @@ class SongTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         songs = json.loads(response.content)
-        self.assertEqual(len(songs), 1)
-        self.assertEqual(songs[0]['name'], 'Baby')
+        self.assertEqual(songs['count'], 1)
+        self.assertEqual(songs['data'][0]['name'], 'Baby')
 
     def test_get_all_songs_single_genre(self):
         self.test_create_valid_song()
@@ -358,8 +358,8 @@ class SongTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         songs = json.loads(response.content)
-        self.assertEqual(len(songs), 1)
-        self.assertEqual(songs[0]['name'], 'Baby')
+        self.assertEqual(songs['count'], 1)
+        self.assertEqual(songs['data'][0]['name'], 'Baby')
 
     def test_get_all_songs_by_artist(self):
         self.test_create_valid_song()
@@ -369,8 +369,8 @@ class SongTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         songs = json.loads(response.content)
-        self.assertEqual(len(songs), 1)
-        self.assertEqual(songs[0]['name'], 'Baby')
+        self.assertEqual(songs['count'], 1)
+        self.assertEqual(songs['data'][0]['name'], 'Baby')
 
     def test_get_all_songs_by_song_name_search(self):
         self.test_create_valid_song()
@@ -380,8 +380,8 @@ class SongTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         songs = json.loads(response.content)
-        self.assertEqual(len(songs), 1)
-        self.assertEqual(songs[0]['name'], 'Baby')
+        self.assertEqual(songs['count'], 1)
+        self.assertEqual(songs['data'][0]['name'], 'Baby')
 
     def test_get_all_songs_by_artist_name_search(self):
         self.test_create_valid_song()
@@ -391,8 +391,8 @@ class SongTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         songs = json.loads(response.content)
-        self.assertEqual(len(songs), 1)
-        self.assertEqual(songs[0]['name'], 'Save a Secret for the Moon')
+        self.assertEqual(songs['count'], 1)
+        self.assertEqual(songs['data'][0]['name'], 'Save a Secret for the Moon')
 
     def test_get_all_songs_ordered_by_year_asc(self):
         self.test_create_valid_song()
@@ -402,9 +402,9 @@ class SongTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         songs = json.loads(response.content)
-        self.assertEqual(len(songs), 2)
-        self.assertEqual(songs[0]['name'], 'Save a Secret for the Moon')
-        self.assertEqual(songs[1]['name'], 'Baby')
+        self.assertEqual(songs['count'], 2)
+        self.assertEqual(songs['data'][0]['name'], 'Save a Secret for the Moon')
+        self.assertEqual(songs['data'][1]['name'], 'Baby')
 
     def test_get_all_songs_ordered_by_year_desc(self):
         self.test_create_valid_song()
@@ -414,9 +414,9 @@ class SongTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         songs = json.loads(response.content)
-        self.assertEqual(len(songs), 2)
-        self.assertEqual(songs[0]['name'], 'Baby')
-        self.assertEqual(songs[1]['name'], 'Save a Secret for the Moon')
+        self.assertEqual(songs['count'], 2)
+        self.assertEqual(songs['data'][0]['name'], 'Baby')
+        self.assertEqual(songs['data'][1]['name'], 'Save a Secret for the Moon')
 
     def test_get_all_songs_ordered_by_song_name(self):
         self.test_create_valid_song()
@@ -426,9 +426,9 @@ class SongTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         songs = json.loads(response.content)
-        self.assertEqual(len(songs), 2)
-        self.assertEqual(songs[0]['name'], 'Baby')
-        self.assertEqual(songs[1]['name'], 'Save a Secret for the Moon')
+        self.assertEqual(songs['count'], 2)
+        self.assertEqual(songs['data'][0]['name'], 'Baby')
+        self.assertEqual(songs['data'][1]['name'], 'Save a Secret for the Moon')
 
     def test_get_all_songs_ordered_by_song_name_desc(self):
         self.test_create_valid_song()
@@ -438,9 +438,9 @@ class SongTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         songs = json.loads(response.content)
-        self.assertEqual(len(songs), 2)
-        self.assertEqual(songs[0]['name'], 'Save a Secret for the Moon')
-        self.assertEqual(songs[1]['name'], 'Baby')
+        self.assertEqual(songs['count'], 2)
+        self.assertEqual(songs['data'][0]['name'], 'Save a Secret for the Moon')
+        self.assertEqual(songs['data'][1]['name'], 'Baby')
 
     def test_get_all_songs_ordered_by_artist_name(self):
         self.test_create_valid_song()
@@ -450,9 +450,9 @@ class SongTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         songs = json.loads(response.content)
-        self.assertEqual(len(songs), 2)
-        self.assertEqual(songs[0]['name'], 'Baby')
-        self.assertEqual(songs[1]['name'], 'Save a Secret for the Moon')
+        self.assertEqual(songs['count'], 2)
+        self.assertEqual(songs['data'][0]['name'], 'Baby')
+        self.assertEqual(songs['data'][1]['name'], 'Save a Secret for the Moon')
 
     def test_get_all_songs_ordered_by_artist_name_desc(self):
         self.test_create_valid_song()
@@ -462,9 +462,9 @@ class SongTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         songs = json.loads(response.content)
-        self.assertEqual(len(songs), 2)
-        self.assertEqual(songs[0]['name'], 'Save a Secret for the Moon')
-        self.assertEqual(songs[1]['name'], 'Baby')
+        self.assertEqual(songs['count'], 2)
+        self.assertEqual(songs['data'][0]['name'], 'Save a Secret for the Moon')
+        self.assertEqual(songs['data'][1]['name'], 'Baby')
 
     def test_get_all_songs_ordered_by_avg_rating_asc(self):
         # creates song id of 1 and two ratings -> avg rating of 4
@@ -494,10 +494,10 @@ class SongTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         songs = json.loads(response.content)
-        self.assertEqual(len(songs), 3)
-        self.assertEqual(songs[0]['avg_rating'], None)
-        self.assertEqual(songs[1]['avg_rating'], 3)
-        self.assertEqual(songs[2]['avg_rating'], 4)
+        self.assertEqual(songs['count'], 3)
+        self.assertEqual(songs['data'][0]['avg_rating'], None)
+        self.assertEqual(songs['data'][1]['avg_rating'], 3)
+        self.assertEqual(songs['data'][2]['avg_rating'], 4)
 
     def test_get_all_songs_ordered_by_avg_rating_desc(self):
         # creates song id of 1 and two ratings -> avg rating of 4
@@ -527,10 +527,10 @@ class SongTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         songs = json.loads(response.content)
-        self.assertEqual(len(songs), 3)
-        self.assertEqual(songs[0]['avg_rating'], 4)
-        self.assertEqual(songs[1]['avg_rating'], 3)
-        self.assertEqual(songs[2]['avg_rating'], None)
+        self.assertEqual(songs['count'], 3)
+        self.assertEqual(songs['data'][0]['avg_rating'], 4)
+        self.assertEqual(songs['data'][1]['avg_rating'], 3)
+        self.assertEqual(songs['data'][2]['avg_rating'], None)
 
     def test_avg_rating_with_no_ratings(self):
         self.test_create_valid_song()


### PR DESCRIPTION
This PR implements pagination on the server. Lists can optionally have their results given as paginated if the `page` and optional `pageSize` query string params are used on lists. The responses for all list methods have been changed from just an array of results, to an object with a `count` key indicating how many total results there are, and a `data` key that holds the array of results. Tests are updated to match this new strategy.