### PR TITLE
remove duplicate song rating in ratings fixtures

### DIFF
--- a/rmmapi/fixtures/ratings.json
+++ b/rmmapi/fixtures/ratings.json
@@ -38,7 +38,7 @@
     "fields": {
       "rating": 4,
       "review": "A banger of a song.",
-      "song_id": 3,
+      "song_id": 4,
       "rater_id": 2,
       "created_at": "2020-11-22T12:00:00Z"
     }


### PR DESCRIPTION
Accidentally rated the same song twice as the same user in ratings fixtures. Fixed that.